### PR TITLE
feat: add file serilizer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
       targets: ["ImageSerializationPlugin"]
     ),
     .library(
+      name: "FileSerializationPlugin",
+      targets: ["FileSerializationPlugin"]
+    ),
+    .library(
       name: "InlineSnapshotTesting",
       targets: ["InlineSnapshotTesting"]
     ),
@@ -35,11 +39,16 @@ let package = Package(
     .target(
       name: "SnapshotTesting",
       dependencies: [
+        "FileSerializationPlugin",
         "ImageSerializationPlugin",
         "SnapshotTestingPlugin"
       ]
     ),
     .target(name: "SnapshotTestingPlugin"),
+    .target(
+      name: "FileSerializationPlugin",
+      dependencies: ["SnapshotTestingPlugin"]
+    ),
     .target(
       name: "ImageSerializationPlugin",
       dependencies: ["SnapshotTestingPlugin"]

--- a/Sources/FileSerializationPlugin/FileSerializationPlugin.swift
+++ b/Sources/FileSerializationPlugin/FileSerializationPlugin.swift
@@ -3,10 +3,15 @@ import Foundation
 
 public typealias FileSerializationPlugin = FileSerialization & SnapshotTestingPlugin
 
-public protocol FileSerialization {
+@preconcurrency public protocol FileSerialization {
+  associatedtype Configuration
   static var location: FileSerializationLocation { get }
   func write(_ data: Data, to url: URL, options: Data.WritingOptions) async throws
   func read(_ url: URL) async throws -> Data?
+
+  // This should not be called ofter
+  func start(_ configuration: Configuration) async throws
+  func stop() async throws
 }
 
 public enum FileSerializationLocation: RawRepresentable, Sendable, Equatable {

--- a/Sources/FileSerializationPlugin/FileSerializationPlugin.swift
+++ b/Sources/FileSerializationPlugin/FileSerializationPlugin.swift
@@ -1,0 +1,30 @@
+import SnapshotTestingPlugin
+import Foundation
+
+public typealias FileSerializationPlugin = FileSerialization & SnapshotTestingPlugin
+
+public protocol FileSerialization {
+  static var location: FileSerializationLocation { get }
+  func write(_ data: Data, to url: URL, options: Data.WritingOptions) async throws
+  func read(_ url: URL) async throws -> Data?
+}
+
+public enum FileSerializationLocation: RawRepresentable, Sendable, Equatable {
+  
+  public static let defaultValue: FileSerializationLocation = .local
+  
+  case local
+  
+  case plugins(String)
+  
+  public init?(rawValue: String) {
+    self = rawValue == "local" ? .local : .plugins(rawValue)
+  }
+  
+  public var rawValue: String {
+    switch self {
+    case .local: return "local"
+    case let .plugins(value): return value
+    }
+  }
+}

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -6,7 +6,6 @@ import Foundation
   import SwiftSyntax
   import SwiftSyntaxBuilder
   import XCTest
-  import FileSerializationPlugin
 
   /// Asserts that a given value matches an inline string snapshot.
   ///

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -6,6 +6,7 @@ import Foundation
   import SwiftSyntax
   import SwiftSyntaxBuilder
   import XCTest
+  import FileSerializationPlugin
 
   /// Asserts that a given value matches an inline string snapshot.
   ///

--- a/Sources/SnapshotTesting/Plugins/FileSerializer.swift
+++ b/Sources/SnapshotTesting/Plugins/FileSerializer.swift
@@ -5,7 +5,7 @@ import FileSerializationPlugin
 final class FileSerializer {
   
   /// A collection of plugins that conform to the `FileSerialization` protocol.
-  private let plugins: [FileSerialization]
+  private let plugins: [any FileSerialization]
   
   init() {
     self.plugins = PluginRegistry.allPlugins()

--- a/Sources/SnapshotTesting/Plugins/FileSerializer.swift
+++ b/Sources/SnapshotTesting/Plugins/FileSerializer.swift
@@ -1,0 +1,57 @@
+#if canImport(SwiftUI)
+import Foundation
+import FileSerializationPlugin
+
+final class FileSerializer {
+  
+  /// A collection of plugins that conform to the `FileSerialization` protocol.
+  private let plugins: [FileSerialization]
+  
+  init() {
+    self.plugins = PluginRegistry.allPlugins()
+  }
+  
+  func write(_ data: Data, to url: URL, options: Data.WritingOptions = [], location: FileSerializationLocation = .defaultValue) throws {
+    if let plugin = self.plugins.first(where: { type(of: $0).location == location }) {
+      Task {
+        try await plugin.write(data, to: url, options: options)
+      }
+      return
+    }
+    
+    try data.write(to: url)
+  }
+  
+  
+  func read(_ url: URL, location: FileSerializationLocation = .defaultValue) throws -> Data? {
+    if let plugin = self.plugins.first(where: { type(of: $0).location == location }) {
+      let semaphore = DispatchSemaphore(value: 0)
+      var result: Result<Data?, Error>?
+      
+      Task {
+        do {
+          let data = try await plugin.read(url)
+          result = .success(data)
+        } catch {
+          result = .failure(error)
+        }
+        semaphore.signal() // Release the semaphore once async task is done
+      }
+      
+      semaphore.wait() // Wait for async task to complete
+      
+      switch result {
+      case .success(let data):
+        return data
+      case .failure(let error):
+        throw error
+      case .none:
+        fatalError("Unexpected error occurred")
+      }
+    }
+    
+    // Synchronous path for fallback
+    return try Data(contentsOf: url)
+  }
+}
+#endif

--- a/Tests/SnapshotTestingTests/FileSerializationPluginTests.swift
+++ b/Tests/SnapshotTestingTests/FileSerializationPluginTests.swift
@@ -1,0 +1,83 @@
+#if canImport(SwiftUI) && canImport(ObjectiveC)
+import XCTest
+import SnapshotTestingPlugin
+@testable import SnapshotTesting
+import FileSerializationPlugin
+
+class InMemoryFileSerializationPlugin: FileSerializationPlugin {
+  static var location: FileSerializationLocation = .plugins("inMemory")
+  var inMemory: [String: Data] = [:]
+  
+  func write(_ data: Data, to url: URL, options: Data.WritingOptions) async throws {
+    inMemory[url.absoluteString] = data
+  }
+  
+  func read(_ url: URL) async throws -> Data? {
+    return inMemory[url.absoluteString]
+  }
+  
+  // MARK: - SnapshotTestingPlugin
+  static var identifier: String = "FileSerializationPlugin.InMemoryFileSerializationPlugin.mock"
+  required init() {}
+}
+
+class FileSerializerTests: XCTestCase {
+  
+  var fileSerializer: FileSerializer!
+  let testData = "Test Data".data(using: .utf8)!
+  let testURL = URL(string: "file:///test.txt")!
+  
+  override func setUp() {
+    super.setUp()
+    PluginRegistry.reset() // Reset state before each test
+    
+    // Register the mock plugin in the PluginRegistry
+    PluginRegistry.registerPlugin(InMemoryFileSerializationPlugin() as SnapshotTestingPlugin)
+    
+    fileSerializer = FileSerializer()
+  }
+  
+  override func tearDown() {
+    fileSerializer = nil
+    PluginRegistry.reset() // Reset state after each test
+    super.tearDown()
+  }
+  
+  func testReadAndWriteUsingMockPlugin() async throws {
+    try fileSerializer.write(
+      testData,
+      to: testURL,
+      location: InMemoryFileSerializationPlugin.location
+    )
+    
+    let storedData = try fileSerializer.read(testURL, location: InMemoryFileSerializationPlugin.location)
+    XCTAssertNotNil(storedData, "Data should be stored in the in-memory plugin.")
+    XCTAssertEqual(storedData, testData, "Stored data should match the test data.")
+  }
+
+  func testReadAndWriteDefaultPlugin() async throws {
+    let tmpURL = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+    try fileSerializer.write(
+      testData,
+      to: tmpURL
+    )
+    
+    let storedData = try fileSerializer.read(tmpURL)
+    XCTAssertNotNil(storedData, "Data should be stored in the in-memory plugin.")
+    XCTAssertEqual(storedData, testData, "Stored data should match the test data.")
+  }
+
+  func testReadNonExistantFileUsingMockPlugin() async throws {
+    let data = try fileSerializer.read(URL(string: "https://www.pointfree.co")!, location: InMemoryFileSerializationPlugin.location)
+    XCTAssertNil(data, "This should be empty.")
+  }
+  
+  func testPluginRegistryShouldContainRegisteredPlugins() {
+    let plugins = PluginRegistry.allPlugins() as [FileSerialization]
+    
+    XCTAssertEqual(plugins.count, 1, "There should be one registered plugin.")
+    XCTAssertEqual(type(of: plugins[0]).location.rawValue, "inMemory", "The plugin should support the 'inMemory' location.")
+  }
+}
+
+#endif


### PR DESCRIPTION
> [!CAUTION]
> This is a work in progress—**do not use**.

### Overview

This is a test implementation of a plugin API for `FileSerializer`, but it has proven to be significantly more challenging to implement correctly compared to `ImageSerializer`.

### Areas to be Improved

- [ ] Concurrency handling requires further refinement.
- [ ] We need a more flexible way to customize SFTP/FTP/S3 configurations.
- [ ] There should be a mechanism to ensure the plugin starts and stops once.
- [ ] Good, structured concurrency support is necessary.

### Test Plugin

At this point, the plugin is highly experimental and should **not** be used in any production environment. It is intended purely for testing and exploration.

Check it out here: https://github.com/mackoj/swift-snapshot-testing-plugin-sftp